### PR TITLE
added a % sign to remove extra space causing overfull hboxes

### DIFF
--- a/beamerthemeMathDept.sty
+++ b/beamerthemeMathDept.sty
@@ -474,7 +474,7 @@
                 \hspace*{2em}
                 \insertframenumber{} / \inserttotalframenumber
                 \hspace*{3.845mm}
-        \end{beamercolorbox}
+        \end{beamercolorbox}%
     }
     \vskip0pt
 }


### PR DESCRIPTION
Had overfull hboxes due to the footline, but solved by adding the extra % sign. See https://tex.stackexchange.com/a/459382  .